### PR TITLE
fix: Updating InitWithConfig to properly pass kindConfig string

### DIFF
--- a/simple.go
+++ b/simple.go
@@ -58,10 +58,8 @@ func InitWithConfig(clusterName, kindConfig string) error {
 	kindCluster, err = Create(
 		clusterName,
 		kubeconfig.Name(),
-		`
-kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
-    `)
+		kindConfig
+	)
 	return err
 }
 


### PR DESCRIPTION
I know it's been 4 years, but this library is awesome! Proposing to correct a small error where the supplied config is not passed through in InitWithConfig()